### PR TITLE
Set up app to use Ettin for configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+source "https://gems.www.lib.umich.edu"
 source 'https://rubygems.org'
 
 git_source(:github) do |repo_name|
@@ -5,6 +6,8 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
+# Use Ettin for configuration
+gem 'ettin'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.1.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,5 @@
 GEM
+  remote: https://gems.www.lib.umich.edu/
   remote: https://rubygems.org/
   specs:
     actioncable (5.1.6)
@@ -53,6 +54,7 @@ GEM
       xpath (>= 2.0, < 4.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -62,7 +64,10 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
     crass (1.0.4)
+    deep_merge (1.2.1)
     erubi (1.7.1)
+    ettin (1.1.5)
+      deep_merge
     execjs (2.7.0)
     ffi (1.9.25)
     globalid (0.4.1)
@@ -89,6 +94,9 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     public_suffix (3.0.2)
     puma (3.12.0)
     rack (2.0.5)
@@ -178,8 +186,10 @@ DEPENDENCIES
   byebug
   capybara (~> 2.13)
   coffee-rails (~> 4.2)
+  ettin
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
+  pry
   puma (~> 3.7)
   rails (~> 5.1.6)
   sass-rails (~> 5.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,8 +11,24 @@ module SampleFauxpaasApp
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
 
+    # Tell rails to look for code in places we're actually going to keep code
+    config.autoload_paths << Rails.root.join("lib")
+    config.autoload_paths << Rails.root.join("app/presenters")
+    config.eager_load_paths << Rails.root.join("app/presenters")
+
+
+    # Now we can actually load the config and make it available
+    require 'sample_fauxpaas_app/config'
+
+    config.relative_url_root                   = SampleFauxpaasApp::Config.relative_url_root
+    config.action_controller.relative_url_root = config.relative_url_root
+
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+
+
+
   end
 end

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,5 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
+require 'pathname'
+require 'tmpdir' # otherwise Dir.tmpdir fails. Really, ruby? C'mon!

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -5,6 +5,6 @@ test:
   adapter: async
 
 production:
-  adapter: redis
-  url: redis://localhost:6379/1
-  channel_prefix: sample_fauxpaas_app_production
+  adapter: <%= SampleFauxpaasApp::Config.cable.adapter %>
+  url: <%= SampleFauxpaasApp::Config.cable.url %>
+  channel_prefix: <%= SampleFauxpaasApp::Config.cable.channel_prefix %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,6 +20,8 @@ test:
   <<: *default
   database: db/test.sqlite3
 
+# Production DB url comes from A&E via the A&E-maintained initializers.yml
 production:
   <<: *default
-  database: db/production.sqlite3
+  url: <%= SampleFauxpaasApp::Config.db.url %>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
+
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -29,4 +29,4 @@ test:
 # and move the `production:` environment over there.
 
 production:
-  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  secret_key_base: <%= SampleFauxpaasApp::Config.secret_key_base %>

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,0 +1,16 @@
+# Local stuff
+
+data_dir: ./data
+log_dir: ./log
+
+
+# We've changed the config files (e.g., cable.yml) to reference our Ettin
+# stuff in SampleFauxpaasApp::Config. On load, it'll attempt to fill in those
+# values, which means all those config paths need to exist in a loaded file.
+#
+# On production, those data are provided by A&E. For dev/test, we need to put
+# in placeholders so calls to the Ettin config object don't error out
+cable:
+  adapter: async
+  url: unused
+  channel_prefix: sample_fauxpaas_app

--- a/config/settings/testing.yml
+++ b/config/settings/testing.yml
@@ -1,0 +1,16 @@
+# Local stuff
+
+data_dir: ./data
+log_dir: ./log
+
+
+# We've changed the config files (e.g., cable.yml) to reference our Ettin
+# stuff in SampleFauxpaasApp::Config. On load, it'll attempt to fill in those
+# values, which means all those config paths need to exist in a loaded file.
+#
+# On production, those data are provided by A&E. For dev/test, we need to put
+# in placeholders so calls to the Ettin config object don't error out
+cable:
+  adapter: async
+  url: unused
+  channel_prefix: sample_fauxpaas_app

--- a/lib/sample_fauxpaas_app/config.rb
+++ b/lib/sample_fauxpaas_app/config.rb
@@ -1,0 +1,42 @@
+require "ettin"
+
+module SampleFauxpaasApp
+  class ConfigSetup
+
+    attr_reader :loaded_config
+    def initialize(env)
+      return @config unless @config.nil?
+      env     ||= if defined? Rails
+                  Rails.env
+                elsif %w[production development test].include? ENV['RAILS_ENV']
+                  ENV['RAILS_ENV']
+                else
+                  "development"
+                end
+      @loaded_config = load_config(env)
+      @loaded_config['app_root'] = Pathname.new(__dir__).parent.parent
+      puts @loaded_config.app_root
+    end
+
+    def load_config(env)
+      config_dir = Pathname.new(__dir__).parent.parent + 'config'
+      Ettin.for(Ettin.settings_files(config_dir, env))
+    end
+
+    def reload_config(env)
+      @loaded_config = load_config(env)
+    end
+
+    def self.config(env = nil)
+      @instance ||= self.new(env)
+      @instance.loaded_config
+    end
+  end
+
+  def self.reload_config!(env = nil)
+    const_set(:Config, ConfigSetup.new(env).loaded_config)
+  end
+
+  # eager load
+  self.reload_config!
+end


### PR DESCRIPTION
Use Ettin for configuration. I do this by:

  * Create config/settings and load it up with appropriate
    yaml files
  * Create a class that loads up the Ettin config files and
    exposes them as SampleFauxpaasApp::Config
  * Add 'app_root' to SampleFauxpaasApp::Config, 'cause it's useful
  * Use SampleFauxpaasApp::Config to provide values to all the
    config/* files. For yaml files, this means using ERB
    expansion.