### PR TITLE
02 Wrap fauxpaas (deployhost) commands for ease

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,11 @@ git_source(:github) do |repo_name|
 end
 
 
+# Use Hanami::CLI for bin/control
+
+gem 'hanami-cli'
+gem 'semantic_logger'
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.1.6'
 # Use sqlite3 as the database for Active Record

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,12 @@ GEM
     ffi (1.9.25)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
+    hanami-cli (0.2.0)
+      concurrent-ruby (~> 1.0)
+      hanami-utils (~> 1.2)
+    hanami-utils (1.2.0)
+      concurrent-ruby (~> 1.0)
+      transproc (~> 1.0)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     jbuilder (2.7.0)
@@ -137,6 +143,8 @@ GEM
     selenium-webdriver (3.13.1)
       childprocess (~> 0.5)
       rubyzip (~> 1.2)
+    semantic_logger (4.3.0)
+      concurrent-ruby (~> 1.0)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -153,6 +161,7 @@ GEM
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
+    transproc (1.0.2)
     turbolinks (5.1.1)
       turbolinks-source (~> 5.1)
     turbolinks-source (5.1.0)
@@ -178,12 +187,14 @@ DEPENDENCIES
   byebug
   capybara (~> 2.13)
   coffee-rails (~> 4.2)
+  hanami-cli
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   puma (~> 3.7)
   rails (~> 5.1.6)
   sass-rails (~> 5.0)
   selenium-webdriver
+  semantic_logger
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3

--- a/bin/control
+++ b/bin/control
@@ -1,0 +1,36 @@
+#!/usr/bin/env ruby
+
+# Before doing anything else, need to
+# force bundler to load up so we
+# can require gems from the Gemfile
+#
+require "pathname"
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
+                                           Pathname.new(__FILE__).realpath)
+require "rubygems"
+require "bundler/setup"
+
+# Add the local lib
+
+$LOAD_PATH.unshift (Pathname(__dir__).parent + 'lib').to_s
+
+# Now we can actually load stuff
+#
+require 'hanami/cli'
+require 'sample_fauxpaas_app/control'
+
+# Set this up as a CLI
+module SampleFauxpaasApp
+  class CLI
+    extend Hanami::CLI::Registry
+  end
+end
+
+
+SampleFauxpaasApp::CLI.register 'deploy', SampleFauxpaasApp::Control::Deploy
+SampleFauxpaasApp::CLI.register 'restart', SampleFauxpaasApp::Control::Restart
+
+SampleFauxpaasApp::CLI.register 'remote', SampleFauxpaasApp::Control::Remote
+SampleFauxpaasApp::CLI.register 'remote-exec', SampleFauxpaasApp::Control::Exec
+
+Hanami::CLI.new(SampleFauxpaasApp::CLI).call

--- a/lib/sample_fauxpaas_app/control.rb
+++ b/lib/sample_fauxpaas_app/control.rb
@@ -1,0 +1,1 @@
+require 'sample_fauxpaas_app/control/remote'

--- a/lib/sample_fauxpaas_app/control/remote.rb
+++ b/lib/sample_fauxpaas_app/control/remote.rb
@@ -1,0 +1,122 @@
+require 'hanami/cli'
+require_relative "../logger"
+
+# Based on the following
+#
+# > ssh deployhost help
+# Password:
+# Password:
+# Duo two-factor login for dueberb
+#
+# Enter a passcode or select one of the following options:
+#
+#  1. Duo Push to XXX-XXX-9591
+#  2. Phone call to XXX-XXX-9591
+#  3. SMS passcodes to XXX-XXX-9591
+#
+# Passcode or option (1-3): ddtltuibkdithjrhttftguedhttgghvvdclhgtitnlvc
+# Commands:
+#   fauxpaas caches <instance>                         # List cached releases f...
+#   fauxpaas default_branch <instance> [<new_branch>]  # Display or set the def...
+#   fauxpaas deploy <instance> [<reference>]           # Deploys the instance u...
+#   fauxpaas exec <instance> <role> <bin> [<args>]     # Run an arbitrary command.
+#   fauxpaas help [COMMAND]                            # Describe available com...
+#   fauxpaas releases <instance>                       # List release history f...
+#   fauxpaas restart <instance>                        # Restart the applicatio...
+#   fauxpaas rollback <instance> [<cache>]             # Initiate a rollback to...
+#   fauxpaas syslog SUBCOMMAND <instance> args...      # Interact with system l...
+#
+# Options:
+#   -v, [--verbose], [--no-verbose]  # Show output from system commands
+#   -u, --user=USER                  # The user running the action, defaults to $USER
+
+module SampleFauxpaasApp
+  class Control
+    extend SampleFauxpaasApp::Logger
+
+    VALID_TARGETS = %w[testing staging production]
+    APP_NAME = 'sample_fauxpaas_app'
+    PANIC_PAUSE = 5
+
+    def self.valid_target?(t)
+      target = t.downcase
+      VALID_TARGETS.include? target
+    end
+
+    def self.validate_target!(t)
+      if valid_target?(t)
+        t.downcase
+      else
+        raise "Target must be one of [#{VALID_TARGETS.join(', ')}]"
+      end
+    end
+
+    def self.remote_exec(target, cmd)
+      logger.info "Telling #{target} to run #{cmd}"
+      full_command = "ssh deployhost exec -v --env=RAILS_ENV:production #{APP_NAME}-#{target} app ruby #{cmd}"
+      system full_command
+    end
+
+    class Deploy < Hanami::CLI::Command
+      include SampleFauxpaasApp::Logger
+
+      desc "Deploy to a valid target (testing/staging/production)"
+      argument :target, required: true, desc: "Which deployment (testing/staging/production)"
+      argument :branch, default: "master", desc: "Which branch/tag/SHA to deploy"
+
+      def call(target:, branch:)
+        target = Remote.validate_target!(target)
+        logger.info "Deploying #{branch} to #{target.upcase}"
+        sleep(Remote::PANIC_PAUSE)
+        system "ssh deployhost deploy -v #{APP_NAME}-#{target} #{branch}"
+      end
+    end
+
+
+    class Restart < Hanami::CLI::Command
+      include SampleFauxpaasApp::Logger
+
+      desc "Restart the puma server for a valid target"
+      argument :target, required: true, desc: "Which deployment (testing/staging/production)"
+
+      def call(target:)
+        target = Remote.validate_target!(target)
+        logger.info "Restarting puma server for #{target.upcase}"
+        system "ssh deployhost restart #{APP_NAME}-#{target}"
+      end
+    end
+
+    class Remote < Hanami::CLI::Command
+      include SampleFauxpaasApp::Logger
+
+      desc "Run a bin/control command on a remote server"
+      argument :target, required: true, desc: "Which deployment (testing/staging/production)"
+      argument :command, required: true, desc: "The command to run (e.g., \"solr reload\" IN DOUBLE QUOTES)"
+      argument :arg1, required: false, default: ''
+      argument :arg2, required: false, default: ''
+      argument :arg3, required: false, default: ''
+
+      def call(target:, command:, arg1:, arg2:, arg3:)
+        target = Control.validate_target!(target)
+        sleep(Control::PANIC_PAUSE)
+        cmd = "bin/dromedary #{[command, arg1, arg2, arg3].join(' ').strip}"
+        Control.remote_exec(target, cmd)
+      end
+    end
+
+    class Exec < Hanami::CLI::Command
+      include SampleFauxpaasApp::Logger
+
+      desc "Run an arbitrary command using deploy exec"
+      argument :target, required: true, desc: "Which deployment (testing/staging/production)"
+      argument :command, required: true, desc: "The command to run (e.g., \"curl http://localhost...\" IN DOUBLE QUOTES)"
+
+      def call(target:, command:)
+        target = Control.validate_target!(target)
+        sleep(Control::PANIC_PAUSE)
+        Control.remote_exec(target, command)
+      end
+    end
+
+  end
+end

--- a/lib/sample_fauxpaas_app/logger.rb
+++ b/lib/sample_fauxpaas_app/logger.rb
@@ -1,0 +1,30 @@
+require 'semantic_logger'
+require 'pathname'
+require_relative 'config'
+
+module SampleFauxpaasApp
+
+
+  module Logger
+
+    class LocalFormatter < SemanticLogger::Formatters::Color
+      def process_info
+        nil
+      end
+    end
+
+
+    FORMATTER = LocalFormatter.new(time_format: "%Y-%m-%d:%H:%M:%S")
+    SemanticLogger.add_appender(io: STDERR, level: :info, formatter: FORMATTER)
+    SemanticLogger.add_appender(io: File.open(SampleFauxpaasApp::Config.app_root + 'log' + 'commands.log', 'a:utf-8'), level: :info, formatter: FORMATTER)
+    LOGGER = SemanticLogger['SampleFauxpaasApp']
+
+    def logger
+      if defined? Rails
+        Rails.application.config.rails_semantic_logger
+      else
+        LOGGER
+      end
+    end
+  end
+end


### PR DESCRIPTION
I wrap the fauxpaas commands to deploy, restart, etc
in order to make things easier to remember. Probably
not useful if this is the only tooling you're doing.

I'm using Hanami::CLI, but of course anything will
work.